### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/libraries/Recaptcha.php
+++ b/libraries/Recaptcha.php
@@ -58,11 +58,11 @@ class Recaptcha
         } else {
             $ch = curl_init();
 
-            curl_setopt($ch, CURLOPT_AUTOREFERER, TRUE);
+            curl_setopt($ch, CURLOPT_AUTOREFERER, true);
             curl_setopt($ch, CURLOPT_HEADER, 0);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
             curl_setopt($ch, CURLOPT_URL, $url);
-            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);       
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);       
 
             $response = curl_exec($ch);
             curl_close($ch);


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!